### PR TITLE
Fix compatibility issues with Faker > 1.9 

### DIFF
--- a/lib/faker_japanese.rb
+++ b/lib/faker_japanese.rb
@@ -10,7 +10,7 @@ module Faker
     WORKDIR = Pathname.new(::File.expand_path(::File.dirname(__FILE__)))
 
     # Kanji string
-    class Kanji < String
+    class Kanji < ::String
       # @return [String] hiragana form
       attr_reader :yomi
       # @return [String] katakana form

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,11 @@
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    Coveralls::SimpleCov::Formatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ])
 SimpleCov.start do
   # disable coverage tracking
   add_filter 'spec' # rspec tests


### PR DESCRIPTION
* [x] use global namespace to reference base String class
* [x] use newer syntax to load multiple formatters for coveralls

Fixes #4 